### PR TITLE
Shift tenant to aggregateId part of streamId

### DIFF
--- a/CQRS_Flow/.NET/Core/Core/Events/StreamNameMapper.cs
+++ b/CQRS_Flow/.NET/Core/Core/Events/StreamNameMapper.cs
@@ -35,8 +35,8 @@ namespace Core.Events
             var tenantPrefix = tenantId == null ? $"{tenantId}_"  : "";
             var category = ToStreamPrefix(streamType);
 
-            // (Out-of-the box, the category projection treats the category as the left bit, based on the `-` separator)
-            // For this reason, we place the "{tenantId}_" bit on the right hand side of the '-' if present
+            // (Out-of-the box, the category projection treats anything before a `-` separator as the category name)
+            // For this reason, we place the "{tenantId}_" bit (if present) on the right hand side of the '-'
             return $"{category}-{tenantPrefix}{aggregateId}";
         }
     }

--- a/CQRS_Flow/.NET/Core/Core/Events/StreamNameMapper.cs
+++ b/CQRS_Flow/.NET/Core/Core/Events/StreamNameMapper.cs
@@ -29,12 +29,15 @@ namespace Core.Events
         public static string ToStreamId<TStream>(object aggregateId, object? tenantId = null) =>
             ToStreamId(typeof(TStream), aggregateId);
 
+        // Generates a stream id in the canonical `{category}-{aggregateId}` format
         public static string ToStreamId(Type streamType, object aggregateId, object? tenantId = null)
         {
-            var tenantPrefix = tenantId != null ? $"{tenantId}_"  : "";
+            var tenantPrefix = tenantId == null ? $"{tenantId}_"  : "";
+            var category = ToStreamPrefix(streamType);
 
-            return $"{tenantPrefix}{ToStreamPrefix(streamType)}-{aggregateId}";
+            // (Out-of-the box, the category projection treats the category as the left bit, based on the `-` separator)
+            // For this reason, we place the "{tenantId}_" bit on the right hand side of the '-' if present
+            return $"{category}-{tenantPrefix}{aggregateId}";
         }
-
     }
 }


### PR DESCRIPTION
While the exact layout of a streamId is pretty arbitrary, in general it works better to have the tenant to the right of the '-' in the streamId as the default category projection treats anything to the left of the first '-' as the category (while this is configurable, this is the default, so Pit Of Success principles apply)