### PR TITLE
Updated .NET Crypto Shredding example to .NET 6, bumped packages to the latest version

### DIFF
--- a/.github/workflows/build.crypto_shredding.dotnet.yml
+++ b/.github/workflows/build.crypto_shredding.dotnet.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: "5.0.x"
+          dotnet-version: "6.0.x"
 
       - name: Restore NuGet packages
         run: dotnet restore

--- a/Crypto_Shredding/.NET/CryptoShredding.sln
+++ b/Crypto_Shredding/.NET/CryptoShredding.sln
@@ -16,6 +16,11 @@ EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CryptoShredding.IntegrationTests", "src\CryptoShredding.IntegrationTests\CryptoShredding.IntegrationTests.csproj", "{FA1C5197-1F19-4EB6-825C-08BB380283AB}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CI", "CI", "{A6E8B7C5-D5F7-4F9E-8EDD-020FEF6D18CD}"
+	ProjectSection(SolutionItems) = preProject
+		..\..\.github\workflows\build.crypto_shredding.dotnet.yml = ..\..\.github\workflows\build.crypto_shredding.dotnet.yml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/Crypto_Shredding/.NET/README.md
+++ b/Crypto_Shredding/.NET/README.md
@@ -6,8 +6,8 @@ Read more in the [Diego Martin](https://github.com/diegosasw) article ["Protecti
 
 ## Prerequisities
 
-- .NET 5.0 - https://dotnet.microsoft.com/download/dotnet/5.0.
-- Visual Studio 2019, Jetbrains Rider or VSCode.
+- .NET 5.0 - https://dotnet.microsoft.com/download/dotnet/6.0.
+- Visual Studio 2022, Jetbrains Rider or VSCode.
 - Docker - https://docs.docker.com/docker-for-windows/install/.
 
 ## Running

--- a/Crypto_Shredding/.NET/docker-compose.yml
+++ b/Crypto_Shredding/.NET/docker-compose.yml
@@ -4,7 +4,9 @@ services:
     #  EventStoreDB - Event Store
     #######################################################
     eventstore.db:
-        image: eventstore/eventstore:21.6.0-buster-slim
+        image: eventstore/eventstore:21.10.0-buster-slim
+        # use this image if you're running ARM-based proc like Apple M1
+        # image: ghcr.io/eventstore/eventstore:21.10.0-alpha-arm64v8
         environment:
             - EVENTSTORE_CLUSTER_SIZE=1
             - EVENTSTORE_RUN_PROJECTIONS=All

--- a/Crypto_Shredding/.NET/src/CryptoShredding.IntegrationTests/CryptoShredding.IntegrationTests.csproj
+++ b/Crypto_Shredding/.NET/src/CryptoShredding.IntegrationTests/CryptoShredding.IntegrationTests.csproj
@@ -1,22 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <VSTestLogger>trx%3bLogFileName=$(MSBuildProjectName).trx</VSTestLogger>
         <VSTestResultsDirectory>$(MSBuildThisFileDirectory)/bin/TestResults/$(TargetFramework)</VSTestResultsDirectory>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="5.10.3" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+        <PackageReference Include="FluentAssertions" Version="6.2.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
         <PackageReference Include="NSubstitute" Version="4.2.2" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="5.0.7" />
+        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Crypto_Shredding/.NET/src/CryptoShredding.IntegrationTests/CryptoShredding.IntegrationTests.csproj
+++ b/Crypto_Shredding/.NET/src/CryptoShredding.IntegrationTests/CryptoShredding.IntegrationTests.csproj
@@ -3,8 +3,6 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <VSTestLogger>trx%3bLogFileName=$(MSBuildProjectName).trx</VSTestLogger>
-        <VSTestResultsDirectory>$(MSBuildThisFileDirectory)/bin/TestResults/$(TargetFramework)</VSTestResultsDirectory>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Crypto_Shredding/.NET/src/CryptoShredding.IntegrationTests/EventStoreTests/GetEventsTests.cs
+++ b/Crypto_Shredding/.NET/src/CryptoShredding.IntegrationTests/EventStoreTests/GetEventsTests.cs
@@ -11,297 +11,296 @@ using EventStore.Client;
 using FluentAssertions;
 using Xunit;
 
-namespace CryptoShredding.IntegrationTests.EventStoreTests
+namespace CryptoShredding.IntegrationTests.EventStoreTests;
+
+public static class GetEventsTests
 {
-    public static class GetEventsTests
+    public class Given_A_ContactBookCreated_And_Two_Events_With_Personal_Data_Stored_When_Getting_Events
+        : Given_WhenAsync_Then_Test
     {
-        public class Given_A_ContactBookCreated_And_Two_Events_With_Personal_Data_Stored_When_Getting_Events
-            : Given_WhenAsync_Then_Test
+        private EventStore _sut;
+        private EventStoreClient _eventStoreClient;
+        private string _streamName;
+        private Guid _joeId;
+        private Guid _janeId;
+        private ContactAdded _expectedContactAddedOne;
+        private ContactAdded _expectedContactAddedTwo;
+        private IEnumerable<IEvent> _result;
+
+        protected override async Task Given()
         {
-            private EventStore _sut;
-            private EventStoreClient _eventStoreClient;
-            private string _streamName;
-            private Guid _joeId;
-            private Guid _janeId;
-            private ContactAdded _expectedContactAddedOne;
-            private ContactAdded _expectedContactAddedTwo;
-            private IEnumerable<IEvent> _result;
+            const string connectionString = "esdb://localhost:2113?tls=false";
+            _eventStoreClient = new EventStoreClient(EventStoreClientSettings.Create(connectionString));
 
-            protected override async Task Given()
-            {
-                const string connectionString = "esdb://localhost:2113?tls=false";
-                _eventStoreClient = new EventStoreClient(EventStoreClientSettings.Create(connectionString));
+            var supportedEvents =
+                new List<Type>
+                {
+                    typeof(ContactBookCreated),
+                    typeof(ContactAdded)
+                };
 
-                var supportedEvents =
-                    new List<Type>
-                    {
-                        typeof(ContactBookCreated),
-                        typeof(ContactAdded)
-                    };
+            var cryptoRepository = new CryptoRepository();
+            var encryptorDecryptor = new EncryptorDecryptor(cryptoRepository);
+            var jsonSerializerSettingsFactory = new JsonSerializerSettingsFactory(encryptorDecryptor);
+            var jsonSerializer = new JsonSerializer(jsonSerializerSettingsFactory, supportedEvents);
+            var eventConverter = new EventConverter(jsonSerializer);
 
-                var cryptoRepository = new CryptoRepository();
-                var encryptorDecryptor = new EncryptorDecryptor(cryptoRepository);
-                var jsonSerializerSettingsFactory = new JsonSerializerSettingsFactory(encryptorDecryptor);
-                var jsonSerializer = new JsonSerializer(jsonSerializerSettingsFactory, supportedEvents);
-                var eventConverter = new EventConverter(jsonSerializer);
-
-                var aggregateId = Guid.NewGuid();
-                _streamName = $"ContactBook-{aggregateId.ToString().Replace("-", string.Empty)}";
+            var aggregateId = Guid.NewGuid();
+            _streamName = $"ContactBook-{aggregateId.ToString().Replace("-", string.Empty)}";
                 
-                _sut = new EventStore(_eventStoreClient, eventConverter);
+            _sut = new EventStore(_eventStoreClient, eventConverter);
 
-                var contactBookCreated =
-                    new ContactBookCreated
-                    {
-                        AggregateId = aggregateId
-                    };
+            var contactBookCreated =
+                new ContactBookCreated
+                {
+                    AggregateId = aggregateId
+                };
 
-                _joeId = Guid.NewGuid();
-                var contactAddedOne =
-                    new ContactAdded
-                    {
-                        AggregateId = aggregateId,
-                        Name = "Joe Bloggs",
-                        Birthday = new DateTime(1984, 1, 1, 0, 0, 0, DateTimeKind.Utc),
-                        PersonId = _joeId,
-                        Address =
-                            new Address
-                            {
-                                Street = "Blue Avenue",
-                                Number = 23,
-                                CountryCode = "ES"
-                            }
-                    };
+            _joeId = Guid.NewGuid();
+            var contactAddedOne =
+                new ContactAdded
+                {
+                    AggregateId = aggregateId,
+                    Name = "Joe Bloggs",
+                    Birthday = new DateTime(1984, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                    PersonId = _joeId,
+                    Address =
+                        new Address
+                        {
+                            Street = "Blue Avenue",
+                            Number = 23,
+                            CountryCode = "ES"
+                        }
+                };
                 
-                _janeId = Guid.NewGuid();
-                var contactAddedTwo =
-                    new ContactAdded
-                    {
-                        AggregateId = aggregateId,
-                        Name = "Jane Bloggs",
-                        Birthday = new DateTime(1987, 12, 31, 0, 0, 0, DateTimeKind.Utc),
-                        PersonId = _janeId,
-                        Address =
-                            new Address
-                            {
-                                Street = "Pink Avenue",
-                                Number = 33,
-                                CountryCode = "ES"
-                            }
-                    };
+            _janeId = Guid.NewGuid();
+            var contactAddedTwo =
+                new ContactAdded
+                {
+                    AggregateId = aggregateId,
+                    Name = "Jane Bloggs",
+                    Birthday = new DateTime(1987, 12, 31, 0, 0, 0, DateTimeKind.Utc),
+                    PersonId = _janeId,
+                    Address =
+                        new Address
+                        {
+                            Street = "Pink Avenue",
+                            Number = 33,
+                            CountryCode = "ES"
+                        }
+                };
                 
-                var eventsToPersist =
-                    new List<IEvent>
-                    {
-                        contactBookCreated,
-                        contactAddedOne,
-                        contactAddedTwo
-                    };
+            var eventsToPersist =
+                new List<IEvent>
+                {
+                    contactBookCreated,
+                    contactAddedOne,
+                    contactAddedTwo
+                };
                 
-                var aggregateVersion = eventsToPersist.Count;
+            var aggregateVersion = eventsToPersist.Count;
 
-                await _sut.PersistEvents(_streamName, aggregateVersion, eventsToPersist);
+            await _sut.PersistEvents(_streamName, aggregateVersion, eventsToPersist);
 
-                _expectedContactAddedOne = contactAddedOne;
-                _expectedContactAddedTwo = contactAddedTwo;
-            }
-
-            protected override async Task When()
-            {
-                _result = await _sut.GetEvents(_streamName);
-            }
-            
-            [Fact]
-            public void Then_It_Should_Retrieve_Three_Events()
-            {
-                _result.Should().HaveCount(3);
-            }
-            
-            [Fact]
-            public void Then_It_Should_Have_Decrypted_The_First_ContactAdded_Event()
-            {
-                _result.ElementAt(1).Should().BeEquivalentTo(_expectedContactAddedOne);
-            }
-            
-            [Fact]
-            public void Then_It_Should_Have_Decrypted_The_Second_ContactAdded_Event()
-            {
-                _result.ElementAt(2).Should().BeEquivalentTo(_expectedContactAddedTwo);
-            }
-
-            protected override void Cleanup()
-            {
-                _eventStoreClient.Dispose();
-            }
+            _expectedContactAddedOne = contactAddedOne;
+            _expectedContactAddedTwo = contactAddedTwo;
         }
-        
-        public class Given_A_ContactBookCreated_And_Two_Events_With_Personal_Data_Stored_And_Encryption_Key_For_One_Is_Deleted_When_Getting_Events
-            : Given_WhenAsync_Then_Test
+
+        protected override async Task When()
         {
-            private EventStore _sut;
-            private EventStoreClient _eventStoreClient;
-            private string _streamName;
-            private Guid _joeId;
-            private Guid _janeId;
-            private ContactAdded _expectedContactAddedOne;
-            private ContactAdded _expectedContactAddedTwo;
-            private IEnumerable<IEvent> _result;
-
-            protected override async Task Given()
-            {
-                const string connectionString = "esdb://localhost:2113?tls=false";
-                _eventStoreClient = new EventStoreClient(EventStoreClientSettings.Create(connectionString));
-
-                var supportedEvents =
-                    new List<Type>
-                    {
-                        typeof(ContactBookCreated),
-                        typeof(ContactAdded)
-                    };
-
-                var cryptoRepository = new CryptoRepository();
-                var encryptorDecryptor = new EncryptorDecryptor(cryptoRepository);
-                var jsonSerializerSettingsFactory = new JsonSerializerSettingsFactory(encryptorDecryptor);
-                var jsonSerializer = new JsonSerializer(jsonSerializerSettingsFactory, supportedEvents);
-                var eventConverter = new EventConverter(jsonSerializer);
-
-                var aggregateId = Guid.NewGuid();
-                _streamName = $"ContactBook-{aggregateId.ToString().Replace("-", string.Empty)}";
-                
-                _sut = new EventStore(_eventStoreClient, eventConverter);
-
-                var contactBookCreated =
-                    new ContactBookCreated
-                    {
-                        AggregateId = aggregateId
-                    };
-
-                _joeId = Guid.NewGuid();
-                var contactAddedOne =
-                    new ContactAdded
-                    {
-                        AggregateId = aggregateId,
-                        Name = "Joe Bloggs",
-                        Birthday = new DateTime(1984, 1, 1, 0, 0, 0, DateTimeKind.Utc),
-                        PersonId = _joeId,
-                        Address =
-                            new Address
-                            {
-                                Street = "Blue Avenue",
-                                Number = 23,
-                                CountryCode = "ES"
-                            }
-                    };
-                
-                _janeId = Guid.NewGuid();
-                var contactAddedTwo =
-                    new ContactAdded
-                    {
-                        AggregateId = aggregateId,
-                        Name = "Jane Bloggs",
-                        Birthday = new DateTime(1987, 12, 31, 0, 0, 0, DateTimeKind.Utc),
-                        PersonId = _janeId,
-                        Address =
-                            new Address
-                            {
-                                Street = "Pink Avenue",
-                                Number = 33,
-                                CountryCode = "ES"
-                            }
-                    };
-                
-                var eventsToPersist =
-                    new List<IEvent>
-                    {
-                        contactBookCreated,
-                        contactAddedOne,
-                        contactAddedTwo
-                    };
-                
-                var aggregateVersion = eventsToPersist.Count;
-
-                await _sut.PersistEvents(_streamName, aggregateVersion, eventsToPersist);
-                cryptoRepository.DeleteEncryptionKey(_janeId.ToString());
-
-                _expectedContactAddedOne = contactAddedOne;
-                _expectedContactAddedTwo =
-                    new ContactAdded
-                    {
-                        AggregateId = aggregateId,
-                        Name = "***",
-                        Birthday = default,
-                        PersonId = _janeId,
-                        Address =
-                            new Address
-                            {
-                                Street = "***",
-                                Number = default,
-                                CountryCode = "ES"
-                            }
-                    };
-            }
-
-            protected override async Task When()
-            {
-                _result = await _sut.GetEvents(_streamName);
-            }
+            _result = await _sut.GetEvents(_streamName);
+        }
             
-            [Fact]
-            public void Then_It_Should_Retrieve_Three_Events()
-            {
-                _result.Should().HaveCount(3);
-            }
+        [Fact]
+        public void Then_It_Should_Retrieve_Three_Events()
+        {
+            _result.Should().HaveCount(3);
+        }
             
-            [Fact]
-            public void Then_It_Should_Have_Decrypted_The_First_ContactAdded_Event()
-            {
-                _result.ElementAt(1).Should().BeEquivalentTo(_expectedContactAddedOne);
-            }
+        [Fact]
+        public void Then_It_Should_Have_Decrypted_The_First_ContactAdded_Event()
+        {
+            _result.ElementAt(1).Should().BeEquivalentTo(_expectedContactAddedOne);
+        }
             
-            [Fact]
-            public void Then_It_Should_Have_Decrypted_The_Second_ContactAdded_Event()
-            {
-                _result.ElementAt(2).Should().BeEquivalentTo(_expectedContactAddedTwo);
-            }
+        [Fact]
+        public void Then_It_Should_Have_Decrypted_The_Second_ContactAdded_Event()
+        {
+            _result.ElementAt(2).Should().BeEquivalentTo(_expectedContactAddedTwo);
+        }
 
-            protected override void Cleanup()
-            {
-                _eventStoreClient.Dispose();
-            }
+        protected override void Cleanup()
+        {
+            _eventStoreClient.Dispose();
         }
     }
-
-    public class ContactAdded
-        : IEvent
-    {
-        public Guid AggregateId { get; set; }
         
-        [DataSubjectId]
-        public Guid PersonId { get; set; }
-
-        [PersonalData]
-        public string Name { get; set; }
-
-        [PersonalData]
-        public DateTime Birthday { get; set; }
-
-        public Address Address { get; set; } = new Address();
-    }
-
-    public class Address
+    public class Given_A_ContactBookCreated_And_Two_Events_With_Personal_Data_Stored_And_Encryption_Key_For_One_Is_Deleted_When_Getting_Events
+        : Given_WhenAsync_Then_Test
     {
-        [PersonalData]
-        public string Street { get; set; }
+        private EventStore _sut;
+        private EventStoreClient _eventStoreClient;
+        private string _streamName;
+        private Guid _joeId;
+        private Guid _janeId;
+        private ContactAdded _expectedContactAddedOne;
+        private ContactAdded _expectedContactAddedTwo;
+        private IEnumerable<IEvent> _result;
+
+        protected override async Task Given()
+        {
+            const string connectionString = "esdb://localhost:2113?tls=false";
+            _eventStoreClient = new EventStoreClient(EventStoreClientSettings.Create(connectionString));
+
+            var supportedEvents =
+                new List<Type>
+                {
+                    typeof(ContactBookCreated),
+                    typeof(ContactAdded)
+                };
+
+            var cryptoRepository = new CryptoRepository();
+            var encryptorDecryptor = new EncryptorDecryptor(cryptoRepository);
+            var jsonSerializerSettingsFactory = new JsonSerializerSettingsFactory(encryptorDecryptor);
+            var jsonSerializer = new JsonSerializer(jsonSerializerSettingsFactory, supportedEvents);
+            var eventConverter = new EventConverter(jsonSerializer);
+
+            var aggregateId = Guid.NewGuid();
+            _streamName = $"ContactBook-{aggregateId.ToString().Replace("-", string.Empty)}";
+                
+            _sut = new EventStore(_eventStoreClient, eventConverter);
+
+            var contactBookCreated =
+                new ContactBookCreated
+                {
+                    AggregateId = aggregateId
+                };
+
+            _joeId = Guid.NewGuid();
+            var contactAddedOne =
+                new ContactAdded
+                {
+                    AggregateId = aggregateId,
+                    Name = "Joe Bloggs",
+                    Birthday = new DateTime(1984, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                    PersonId = _joeId,
+                    Address =
+                        new Address
+                        {
+                            Street = "Blue Avenue",
+                            Number = 23,
+                            CountryCode = "ES"
+                        }
+                };
+                
+            _janeId = Guid.NewGuid();
+            var contactAddedTwo =
+                new ContactAdded
+                {
+                    AggregateId = aggregateId,
+                    Name = "Jane Bloggs",
+                    Birthday = new DateTime(1987, 12, 31, 0, 0, 0, DateTimeKind.Utc),
+                    PersonId = _janeId,
+                    Address =
+                        new Address
+                        {
+                            Street = "Pink Avenue",
+                            Number = 33,
+                            CountryCode = "ES"
+                        }
+                };
+                
+            var eventsToPersist =
+                new List<IEvent>
+                {
+                    contactBookCreated,
+                    contactAddedOne,
+                    contactAddedTwo
+                };
+                
+            var aggregateVersion = eventsToPersist.Count;
+
+            await _sut.PersistEvents(_streamName, aggregateVersion, eventsToPersist);
+            cryptoRepository.DeleteEncryptionKey(_janeId.ToString());
+
+            _expectedContactAddedOne = contactAddedOne;
+            _expectedContactAddedTwo =
+                new ContactAdded
+                {
+                    AggregateId = aggregateId,
+                    Name = "***",
+                    Birthday = default,
+                    PersonId = _janeId,
+                    Address =
+                        new Address
+                        {
+                            Street = "***",
+                            Number = default,
+                            CountryCode = "ES"
+                        }
+                };
+        }
+
+        protected override async Task When()
+        {
+            _result = await _sut.GetEvents(_streamName);
+        }
+            
+        [Fact]
+        public void Then_It_Should_Retrieve_Three_Events()
+        {
+            _result.Should().HaveCount(3);
+        }
+            
+        [Fact]
+        public void Then_It_Should_Have_Decrypted_The_First_ContactAdded_Event()
+        {
+            _result.ElementAt(1).Should().BeEquivalentTo(_expectedContactAddedOne);
+        }
+            
+        [Fact]
+        public void Then_It_Should_Have_Decrypted_The_Second_ContactAdded_Event()
+        {
+            _result.ElementAt(2).Should().BeEquivalentTo(_expectedContactAddedTwo);
+        }
+
+        protected override void Cleanup()
+        {
+            _eventStoreClient.Dispose();
+        }
+    }
+}
+
+public class ContactAdded
+    : IEvent
+{
+    public Guid AggregateId { get; set; }
         
-        [PersonalData]
-        public int Number { get; set; }
+    [DataSubjectId]
+    public Guid PersonId { get; set; }
 
-        public string CountryCode { get; set; }
-    }
+    [PersonalData]
+    public string Name { get; set; }
 
-    public class ContactBookCreated
-        : IEvent
-    {
-        public Guid AggregateId { get; set; }
-    }
+    [PersonalData]
+    public DateTime Birthday { get; set; }
+
+    public Address Address { get; set; } = new Address();
+}
+
+public class Address
+{
+    [PersonalData]
+    public string Street { get; set; }
+        
+    [PersonalData]
+    public int Number { get; set; }
+
+    public string CountryCode { get; set; }
+}
+
+public class ContactBookCreated
+    : IEvent
+{
+    public Guid AggregateId { get; set; }
 }

--- a/Crypto_Shredding/.NET/src/CryptoShredding.IntegrationTests/TestSupport/Given_When_Then.cs
+++ b/Crypto_Shredding/.NET/src/CryptoShredding.IntegrationTests/TestSupport/Given_When_Then.cs
@@ -1,33 +1,32 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CryptoShredding.IntegrationTests.TestSupport
+namespace CryptoShredding.IntegrationTests.TestSupport;
+
+public abstract class Given_WhenAsync_Then_Test
+    : IDisposable
 {
-    public abstract class Given_WhenAsync_Then_Test
-        : IDisposable
+    protected Given_WhenAsync_Then_Test()
     {
-        protected Given_WhenAsync_Then_Test()
-        {
-            Task.Run((Func<Task>) (async () => await this.SetupAsync())).Wait();
-        }
+        Task.Run((Func<Task>) (async () => await this.SetupAsync())).Wait();
+    }
 
-        private async Task SetupAsync()
-        {
-            await Given();
-            await When();
-        }
+    private async Task SetupAsync()
+    {
+        await Given();
+        await When();
+    }
 
-        protected abstract Task Given();
+    protected abstract Task Given();
 
-        protected abstract Task When();
+    protected abstract Task When();
 
-        public void Dispose()
-        {
-            Cleanup();
-        }
+    public void Dispose()
+    {
+        Cleanup();
+    }
 
-        protected virtual void Cleanup()
-        {
-        }
+    protected virtual void Cleanup()
+    {
     }
 }

--- a/Crypto_Shredding/.NET/src/CryptoShredding/Attributes/DataSubjectIdAttribute.cs
+++ b/Crypto_Shredding/.NET/src/CryptoShredding/Attributes/DataSubjectIdAttribute.cs
@@ -1,12 +1,11 @@
 using System;
 
-namespace CryptoShredding.Attributes
-{
-    /**
+namespace CryptoShredding.Attributes;
+
+/**
     * Specifies the PII owner (e.g: the person Id)
     */
-    public class DataSubjectIdAttribute 
-        : Attribute
-    {
-    }
+public class DataSubjectIdAttribute 
+    : Attribute
+{
 }

--- a/Crypto_Shredding/.NET/src/CryptoShredding/Attributes/PersonalDataAttribute.cs
+++ b/Crypto_Shredding/.NET/src/CryptoShredding/Attributes/PersonalDataAttribute.cs
@@ -1,12 +1,11 @@
 using System;
 
-namespace CryptoShredding.Attributes
-{
-    /**
+namespace CryptoShredding.Attributes;
+
+/**
      * Specifies the property that holds PII
      */
-    public class PersonalDataAttribute
-        : Attribute
-    {
-    }
+public class PersonalDataAttribute
+    : Attribute
+{
 }

--- a/Crypto_Shredding/.NET/src/CryptoShredding/Contracts/IEvent.cs
+++ b/Crypto_Shredding/.NET/src/CryptoShredding/Contracts/IEvent.cs
@@ -1,6 +1,5 @@
-namespace CryptoShredding.Contracts
+namespace CryptoShredding.Contracts;
+
+public interface IEvent
 {
-    public interface IEvent
-    {
-    }
 }

--- a/Crypto_Shredding/.NET/src/CryptoShredding/CryptoShredding.csproj
+++ b/Crypto_Shredding/.NET/src/CryptoShredding/CryptoShredding.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="EventStore.Client.Grpc.Streams" Version="21.2.0" />
-        <PackageReference Include="Grpc.Net.Client" Version="2.38.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     </ItemGroup>
 

--- a/Crypto_Shredding/.NET/src/CryptoShredding/EventConverter.cs
+++ b/Crypto_Shredding/.NET/src/CryptoShredding/EventConverter.cs
@@ -2,36 +2,35 @@ using CryptoShredding.Contracts;
 using CryptoShredding.Serialization;
 using EventStore.Client;
 
-namespace CryptoShredding
+namespace CryptoShredding;
+
+public class EventConverter
 {
-    public class EventConverter
+    private readonly JsonSerializer _jsonSerializer;
+
+    public EventConverter(JsonSerializer jsonSerializer)
     {
-        private readonly JsonSerializer _jsonSerializer;
-
-        public EventConverter(JsonSerializer jsonSerializer)
-        {
-            _jsonSerializer = jsonSerializer;
-        }
+        _jsonSerializer = jsonSerializer;
+    }
         
-        public IEvent ToEvent(ResolvedEvent resolvedEvent)
-        {
-            var data = resolvedEvent.Event.Data;
-            var metadata = resolvedEvent.Event.Metadata;
-            var eventName = resolvedEvent.Event.EventType;
-            var persistableEvent = _jsonSerializer.Deserialize(data, metadata, eventName);
-            return persistableEvent;
-        }
+    public IEvent ToEvent(ResolvedEvent resolvedEvent)
+    {
+        var data = resolvedEvent.Event.Data;
+        var metadata = resolvedEvent.Event.Metadata;
+        var eventName = resolvedEvent.Event.EventType;
+        var persistableEvent = _jsonSerializer.Deserialize(data, metadata, eventName);
+        return persistableEvent;
+    }
 
-        public EventData ToEventData(IEvent @event)
-        {
-            var eventTypeName = @event.GetType().Name;
-            var id = Uuid.NewUuid();
-            var serializedEvent = _jsonSerializer.Serialize(@event);
-            var contentType = serializedEvent.IsJson ? "application/json" : "application/octet-stream";
-            var data = serializedEvent.Data;
-            var metadata = serializedEvent.MetaData;
-            var eventData = new EventData(id, eventTypeName,data, metadata, contentType);
-            return eventData;
-        }
+    public EventData ToEventData(IEvent @event)
+    {
+        var eventTypeName = @event.GetType().Name;
+        var id = Uuid.NewUuid();
+        var serializedEvent = _jsonSerializer.Serialize(@event);
+        var contentType = serializedEvent.IsJson ? "application/json" : "application/octet-stream";
+        var data = serializedEvent.Data;
+        var metadata = serializedEvent.MetaData;
+        var eventData = new EventData(id, eventTypeName,data, metadata, contentType);
+        return eventData;
     }
 }

--- a/Crypto_Shredding/.NET/src/CryptoShredding/EventStore.cs
+++ b/Crypto_Shredding/.NET/src/CryptoShredding/EventStore.cs
@@ -4,59 +4,58 @@ using System.Threading.Tasks;
 using CryptoShredding.Contracts;
 using EventStore.Client;
 
-namespace CryptoShredding
+namespace CryptoShredding;
+
+public class EventStore
 {
-    public class EventStore
+    private readonly EventStoreClient _eventStoreClient;
+    private readonly EventConverter _eventConverter;
+
+    public EventStore(
+        EventStoreClient eventStoreClient,
+        EventConverter eventConverter)
     {
-        private readonly EventStoreClient _eventStoreClient;
-        private readonly EventConverter _eventConverter;
-
-        public EventStore(
-            EventStoreClient eventStoreClient,
-            EventConverter eventConverter)
-        {
-            _eventStoreClient = eventStoreClient;
-            _eventConverter = eventConverter;
-        }
+        _eventStoreClient = eventStoreClient;
+        _eventConverter = eventConverter;
+    }
         
-        public async Task PersistEvents(string streamName, int aggregateVersion, IEnumerable<IEvent> eventsToPersist)
+    public async Task PersistEvents(string streamName, int aggregateVersion, IEnumerable<IEvent> eventsToPersist)
+    {
+        var events = eventsToPersist.ToList();
+        var count = events.Count;
+        if (count == 0)
         {
-            var events = eventsToPersist.ToList();
-            var count = events.Count;
-            if (count == 0)
-            {
-                return;
-            }
-
-            var expectedRevision = GetExpectedRevision(aggregateVersion, count);
-            var eventsData =
-                events.Select(x => _eventConverter.ToEventData(x));
-            if (expectedRevision == null)
-                await _eventStoreClient.AppendToStreamAsync(streamName, StreamState.NoStream, eventsData);
-            else
-                await _eventStoreClient.AppendToStreamAsync(streamName, expectedRevision.Value, eventsData);
+            return;
         }
 
-        public async Task<IEnumerable<IEvent>> GetEvents(string streamName)
-        {
-            const int start = 0;
-            const int count = 4096;
-            const bool resolveLinkTos = false;
-            var sliceEvents =
-                _eventStoreClient.ReadStreamAsync(Direction.Forwards, streamName, start, count, resolveLinkTos: resolveLinkTos);
-            var resolvedEvents = await sliceEvents.ToListAsync();
-            var events =
-                resolvedEvents.Select(x => _eventConverter.ToEvent(x));
-            return events;
-        }
+        var expectedRevision = GetExpectedRevision(aggregateVersion, count);
+        var eventsData =
+            events.Select(x => _eventConverter.ToEventData(x));
+        if (expectedRevision == null)
+            await _eventStoreClient.AppendToStreamAsync(streamName, StreamState.NoStream, eventsData);
+        else
+            await _eventStoreClient.AppendToStreamAsync(streamName, expectedRevision.Value, eventsData);
+    }
+
+    public async Task<IEnumerable<IEvent>> GetEvents(string streamName)
+    {
+        const int start = 0;
+        const int count = 4096;
+        const bool resolveLinkTos = false;
+        var sliceEvents =
+            _eventStoreClient.ReadStreamAsync(Direction.Forwards, streamName, start, count, resolveLinkTos: resolveLinkTos);
+        var resolvedEvents = await sliceEvents.ToListAsync();
+        var events =
+            resolvedEvents.Select(x => _eventConverter.ToEvent(x));
+        return events;
+    }
         
-        private StreamRevision? GetExpectedRevision(int aggregateVersion, int numberOfEvents)
-        {
-            var originalVersion = aggregateVersion - numberOfEvents;
-            var expectedVersion = originalVersion != 0
-                ? StreamRevision.FromInt64(originalVersion - 1)
-                : (StreamRevision?)null;
-            return expectedVersion;
-        }
+    private StreamRevision? GetExpectedRevision(int aggregateVersion, int numberOfEvents)
+    {
+        var originalVersion = aggregateVersion - numberOfEvents;
+        var expectedVersion = originalVersion != 0
+            ? StreamRevision.FromInt64(originalVersion - 1)
+            : (StreamRevision?)null;
+        return expectedVersion;
     }
 }

--- a/Crypto_Shredding/.NET/src/CryptoShredding/Repository/CryptoRepository.cs
+++ b/Crypto_Shredding/.NET/src/CryptoShredding/Repository/CryptoRepository.cs
@@ -1,44 +1,43 @@
 using System;
 using System.Collections.Generic;
 
-namespace CryptoShredding.Repository
+namespace CryptoShredding.Repository;
+
+public class CryptoRepository
 {
-    public class CryptoRepository
+    private readonly IDictionary<string, EncryptionKey> _cryptoStore;
+
+    public CryptoRepository()
     {
-        private readonly IDictionary<string, EncryptionKey> _cryptoStore;
+        _cryptoStore = new Dictionary<string, EncryptionKey>();
+    }
 
-        public CryptoRepository()
+    public EncryptionKey GetExistingOrNew(string id, Func<EncryptionKey> keyGenerator)
+    {
+        var isExisting = _cryptoStore.TryGetValue(id, out var keyStored);
+        if (isExisting)
         {
-            _cryptoStore = new Dictionary<string, EncryptionKey>();
+            return keyStored;
         }
 
-        public EncryptionKey GetExistingOrNew(string id, Func<EncryptionKey> keyGenerator)
-        {
-            var isExisting = _cryptoStore.TryGetValue(id, out var keyStored);
-            if (isExisting)
-            {
-                return keyStored;
-            }
-
-            var newEncryptionKey = keyGenerator.Invoke();
-            _cryptoStore.Add(id, newEncryptionKey);
-            return newEncryptionKey;
-        }
+        var newEncryptionKey = keyGenerator.Invoke();
+        _cryptoStore.Add(id, newEncryptionKey);
+        return newEncryptionKey;
+    }
         
-        public EncryptionKey GetExistingOrDefault(string id)
+    public EncryptionKey GetExistingOrDefault(string id)
+    {
+        var isExisting = _cryptoStore.TryGetValue(id, out var keyStored);
+        if (isExisting)
         {
-            var isExisting = _cryptoStore.TryGetValue(id, out var keyStored);
-            if (isExisting)
-            {
-                return keyStored;
-            }
-
-            return default;
+            return keyStored;
         }
 
-        public void DeleteEncryptionKey(string id)
-        {
-            _cryptoStore.Remove(id);
-        }
+        return default;
+    }
+
+    public void DeleteEncryptionKey(string id)
+    {
+        _cryptoStore.Remove(id);
     }
 }

--- a/Crypto_Shredding/.NET/src/CryptoShredding/Repository/EncryptionKey.cs
+++ b/Crypto_Shredding/.NET/src/CryptoShredding/Repository/EncryptionKey.cs
@@ -1,16 +1,15 @@
-namespace CryptoShredding.Repository
+namespace CryptoShredding.Repository;
+
+public class EncryptionKey
 {
-    public class EncryptionKey
-    {
-        public byte[] Key { get; }
-        public byte[] Nonce { get; }
+    public byte[] Key { get; }
+    public byte[] Nonce { get; }
         
-        public EncryptionKey(
-            byte[] key,
-            byte[] nonce)
-        {
-            Key = key;
-            Nonce = nonce;
-        }
+    public EncryptionKey(
+        byte[] key,
+        byte[] nonce)
+    {
+        Key = key;
+        Nonce = nonce;
     }
 }

--- a/Crypto_Shredding/.NET/src/CryptoShredding/Serialization/ContractResolvers/SerializationContractResolver.cs
+++ b/Crypto_Shredding/.NET/src/CryptoShredding/Serialization/ContractResolvers/SerializationContractResolver.cs
@@ -7,52 +7,51 @@ using CryptoShredding.Serialization.JsonConverters;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
-namespace CryptoShredding.Serialization.ContractResolvers
+namespace CryptoShredding.Serialization.ContractResolvers;
+
+public class SerializationContractResolver
+    : DefaultContractResolver
 {
-    public class SerializationContractResolver
-        : DefaultContractResolver
+    private readonly ICryptoTransform _encryptor;
+    private readonly FieldEncryptionDecryption _fieldEncryptionDecryption;
+
+    public SerializationContractResolver(
+        ICryptoTransform encryptor,
+        FieldEncryptionDecryption fieldEncryptionDecryption)
     {
-        private readonly ICryptoTransform _encryptor;
-        private readonly FieldEncryptionDecryption _fieldEncryptionDecryption;
+        _encryptor = encryptor;
+        _fieldEncryptionDecryption = fieldEncryptionDecryption;
+        NamingStrategy = new CamelCaseNamingStrategy();
+    }
 
-        public SerializationContractResolver(
-            ICryptoTransform encryptor,
-            FieldEncryptionDecryption fieldEncryptionDecryption)
+    protected override IList<JsonProperty> CreateProperties(Type type, MemberSerialization memberSerialization)
+    {
+        var properties = base.CreateProperties(type, memberSerialization);
+        foreach (var jsonProperty in properties)
         {
-            _encryptor = encryptor;
-            _fieldEncryptionDecryption = fieldEncryptionDecryption;
-            NamingStrategy = new CamelCaseNamingStrategy();
-        }
-
-        protected override IList<JsonProperty> CreateProperties(Type type, MemberSerialization memberSerialization)
-        {
-            var properties = base.CreateProperties(type, memberSerialization);
-            foreach (var jsonProperty in properties)
+            var isPersonalIdentifiableInformation = IsPersonalIdentifiableInformation(type, jsonProperty);
+            if (isPersonalIdentifiableInformation)
             {
-                var isPersonalIdentifiableInformation = IsPersonalIdentifiableInformation(type, jsonProperty);
-                if (isPersonalIdentifiableInformation)
-                {
-                    var serializationJsonConverter = new EncryptionJsonConverter(_encryptor, _fieldEncryptionDecryption);
-                    jsonProperty.Converter = serializationJsonConverter;
-                }
+                var serializationJsonConverter = new EncryptionJsonConverter(_encryptor, _fieldEncryptionDecryption);
+                jsonProperty.Converter = serializationJsonConverter;
             }
-            return properties;
         }
+        return properties;
+    }
         
-        private bool IsPersonalIdentifiableInformation(Type type, JsonProperty jsonProperty)
+    private bool IsPersonalIdentifiableInformation(Type type, JsonProperty jsonProperty)
+    {
+        var propertyInfo = type.GetProperty(jsonProperty.UnderlyingName);
+        if (propertyInfo is null)
         {
-            var propertyInfo = type.GetProperty(jsonProperty.UnderlyingName);
-            if (propertyInfo is null)
-            {
-                return false;
-            }
-            var hasPersonalDataAttribute =
-                propertyInfo.CustomAttributes
-                    .Any(x => x.AttributeType == typeof(PersonalDataAttribute));
-            var propertyType = propertyInfo.PropertyType;
-            var isSimpleValue = propertyType.IsValueType || propertyType == typeof(string);
-            var isSupportedPersonalIdentifiableInformation = isSimpleValue && hasPersonalDataAttribute;
-            return isSupportedPersonalIdentifiableInformation;
+            return false;
         }
+        var hasPersonalDataAttribute =
+            propertyInfo.CustomAttributes
+                .Any(x => x.AttributeType == typeof(PersonalDataAttribute));
+        var propertyType = propertyInfo.PropertyType;
+        var isSimpleValue = propertyType.IsValueType || propertyType == typeof(string);
+        var isSupportedPersonalIdentifiableInformation = isSimpleValue && hasPersonalDataAttribute;
+        return isSupportedPersonalIdentifiableInformation;
     }
 }

--- a/Crypto_Shredding/.NET/src/CryptoShredding/Serialization/EncryptorDecryptor.cs
+++ b/Crypto_Shredding/.NET/src/CryptoShredding/Serialization/EncryptorDecryptor.cs
@@ -15,8 +15,8 @@ public class EncryptorDecryptor
     public ICryptoTransform GetEncryptor(string dataSubjectId)
     {
         var encryptionKey = _cryptoRepository.GetExistingOrNew(dataSubjectId, CreateNewEncryptionKey);
-        var aesManaged = GetAesManaged(encryptionKey);
-        var encryptor = aesManaged.CreateEncryptor();
+        var aes = GetAes(encryptionKey);
+        var encryptor = aes.CreateEncryptor();
         return encryptor;
     }
 
@@ -29,8 +29,8 @@ public class EncryptorDecryptor
             return default;
         }
             
-        var aesManaged = GetAesManaged(encryptionKey);
-        var decryptor = aesManaged.CreateDecryptor();
+        var aes = GetAes(encryptionKey);
+        var decryptor = aes.CreateDecryptor();
         return decryptor;
     }
         
@@ -47,7 +47,7 @@ public class EncryptorDecryptor
         return encryptionKey;
     }
         
-    private Aes GetAesManaged(EncryptionKey encryptionKey)
+    private Aes GetAes(EncryptionKey encryptionKey)
     {
         var aes = Aes.Create();
 

--- a/Crypto_Shredding/.NET/src/CryptoShredding/Serialization/JsonConverters/DecryptionJsonConverter.cs
+++ b/Crypto_Shredding/.NET/src/CryptoShredding/Serialization/JsonConverters/DecryptionJsonConverter.cs
@@ -2,40 +2,39 @@ using System;
 using System.Security.Cryptography;
 using Newtonsoft.Json;
 
-namespace CryptoShredding.Serialization.JsonConverters
+namespace CryptoShredding.Serialization.JsonConverters;
+
+public class DecryptionJsonConverter
+    : JsonConverter
 {
-    public class DecryptionJsonConverter
-        : JsonConverter
+    private readonly ICryptoTransform _decryptor;
+    private readonly FieldEncryptionDecryption _fieldEncryptionDecryption;
+
+    public DecryptionJsonConverter(
+        ICryptoTransform decryptor,
+        FieldEncryptionDecryption fieldEncryptionService)
     {
-        private readonly ICryptoTransform _decryptor;
-        private readonly FieldEncryptionDecryption _fieldEncryptionDecryption;
-
-        public DecryptionJsonConverter(
-            ICryptoTransform decryptor,
-            FieldEncryptionDecryption fieldEncryptionService)
-        {
-            _decryptor = decryptor;
-            _fieldEncryptionDecryption = fieldEncryptionService;
-        }
-
-        public override void WriteJson(JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer)
-        {
-            throw new NotImplementedException();
-        }
-
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
-        {
-            var value = reader.Value;
-            var result = _fieldEncryptionDecryption.GetDecryptedOrDefault(value, _decryptor, objectType);
-            return result;
-        }
-
-        public override bool CanConvert(Type objectType)
-        {
-            return true;
-        }
-
-        public override bool CanRead => true;
-        public override bool CanWrite => false;
+        _decryptor = decryptor;
+        _fieldEncryptionDecryption = fieldEncryptionService;
     }
+
+    public override void WriteJson(JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override object ReadJson(JsonReader reader, Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
+    {
+        var value = reader.Value;
+        var result = _fieldEncryptionDecryption.GetDecryptedOrDefault(value, _decryptor, objectType);
+        return result;
+    }
+
+    public override bool CanConvert(Type objectType)
+    {
+        return true;
+    }
+
+    public override bool CanRead => true;
+    public override bool CanWrite => false;
 }

--- a/Crypto_Shredding/.NET/src/CryptoShredding/Serialization/JsonConverters/EncryptionJsonConverter.cs
+++ b/Crypto_Shredding/.NET/src/CryptoShredding/Serialization/JsonConverters/EncryptionJsonConverter.cs
@@ -2,40 +2,39 @@ using System;
 using System.Security.Cryptography;
 using Newtonsoft.Json;
 
-namespace CryptoShredding.Serialization.JsonConverters
+namespace CryptoShredding.Serialization.JsonConverters;
+
+public class EncryptionJsonConverter
+    : JsonConverter
 {
-    public class EncryptionJsonConverter
-        : JsonConverter
+    private readonly ICryptoTransform _encryptor;
+    private readonly FieldEncryptionDecryption _fieldEncryptionDecryption;
+
+    public EncryptionJsonConverter(
+        ICryptoTransform encryptor,
+        FieldEncryptionDecryption fieldEncryptionDecryption)
     {
-        private readonly ICryptoTransform _encryptor;
-        private readonly FieldEncryptionDecryption _fieldEncryptionDecryption;
-
-        public EncryptionJsonConverter(
-            ICryptoTransform encryptor,
-            FieldEncryptionDecryption fieldEncryptionDecryption)
-        {
-            _encryptor = encryptor;
-            _fieldEncryptionDecryption = fieldEncryptionDecryption;
-        }
-
-        public override void WriteJson(JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer)
-        {
-            var result = _fieldEncryptionDecryption.GetEncryptedOrDefault(value, _encryptor);
-            writer.WriteValue(result);
-        }
-
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
-        {
-            throw new NotImplementedException();
-        }
-
-        public override bool CanConvert(Type objectType)
-        {
-            return true;
-        }
-
-        public override bool CanRead => false;
-
-        public override bool CanWrite => true;
+        _encryptor = encryptor;
+        _fieldEncryptionDecryption = fieldEncryptionDecryption;
     }
+
+    public override void WriteJson(JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer)
+    {
+        var result = _fieldEncryptionDecryption.GetEncryptedOrDefault(value, _encryptor);
+        writer.WriteValue(result);
+    }
+
+    public override object ReadJson(JsonReader reader, Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override bool CanConvert(Type objectType)
+    {
+        return true;
+    }
+
+    public override bool CanRead => false;
+
+    public override bool CanWrite => true;
 }

--- a/Crypto_Shredding/.NET/src/CryptoShredding/Serialization/JsonConverters/FieldEncryptionDecryption.cs
+++ b/Crypto_Shredding/.NET/src/CryptoShredding/Serialization/JsonConverters/FieldEncryptionDecryption.cs
@@ -3,90 +3,89 @@ using System.ComponentModel;
 using System.IO;
 using System.Security.Cryptography;
 
-namespace CryptoShredding.Serialization.JsonConverters
+namespace CryptoShredding.Serialization.JsonConverters;
+
+public class FieldEncryptionDecryption
 {
-    public class FieldEncryptionDecryption
-    {
-        private const string EncryptionPrefix = "crypto.";
+    private const string EncryptionPrefix = "crypto.";
         
-        public object GetEncryptedOrDefault(object value, ICryptoTransform encryptor)
+    public object GetEncryptedOrDefault(object value, ICryptoTransform encryptor)
+    {
+        if (encryptor is null)
         {
-            if (encryptor is null)
-            {
-                throw new ArgumentNullException(nameof(encryptor));
-            }
-            var isEncryptionNeeded = value != null;
-            if (isEncryptionNeeded)
-            {
-                using var memoryStream = new MemoryStream();
-                using var cryptoStream = new CryptoStream(memoryStream, encryptor, CryptoStreamMode.Write);
-                using var writer = new StreamWriter(cryptoStream);
-                var valueAsText = value.ToString();
-                writer.Write(valueAsText);
-                writer.Flush();
-                cryptoStream.FlushFinalBlock();
-
-                var encryptedData = memoryStream.ToArray();
-                var encryptedText = Convert.ToBase64String(encryptedData);
-                var result = $"{EncryptionPrefix}{encryptedText}";
-                return result;
-            }
-
-            return default;
+            throw new ArgumentNullException(nameof(encryptor));
         }
-
-        public object GetDecryptedOrDefault(object value, ICryptoTransform decryptor, Type destinationType)
+        var isEncryptionNeeded = value != null;
+        if (isEncryptionNeeded)
         {
-            if (value is null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
-            var isText = value is string;
-            if (isText)
-            {
-                var valueAsText = (string)value;
-                var isEncrypted = valueAsText.StartsWith(EncryptionPrefix);
-                if (isEncrypted)
-                {
-                    var isDecryptorAvailable = decryptor != null;
-                    if (isDecryptorAvailable)
-                    {
-                        var startIndex = EncryptionPrefix.Length;
-                        var valueWithoutPrefix = valueAsText.Substring(startIndex);
-                        var encryptedValue = Convert.FromBase64String(valueWithoutPrefix);
-                        using var memoryStream = new MemoryStream(encryptedValue);
-                        using var cryptoStream = new CryptoStream(memoryStream, decryptor, CryptoStreamMode.Read);
-                        using var reader = new StreamReader(cryptoStream);
-                        var decryptedText = reader.ReadToEnd();
-                        var result = Parse(destinationType, decryptedText);
-                        return result;
-                    }
-                    var maskedValue = GetMaskedValue(destinationType);
-                    return maskedValue;
-                }
-                var valueParsed = Parse(destinationType, valueAsText);
-                return valueParsed;
-            }
+            using var memoryStream = new MemoryStream();
+            using var cryptoStream = new CryptoStream(memoryStream, encryptor, CryptoStreamMode.Write);
+            using var writer = new StreamWriter(cryptoStream);
+            var valueAsText = value.ToString();
+            writer.Write(valueAsText);
+            writer.Flush();
+            cryptoStream.FlushFinalBlock();
 
-            return value;
-        }
-
-        private object Parse(Type outputType, string valueAsString)
-        {
-            var converter = TypeDescriptor.GetConverter(outputType);
-            var result = converter.ConvertFromString(valueAsString);
+            var encryptedData = memoryStream.ToArray();
+            var encryptedText = Convert.ToBase64String(encryptedData);
+            var result = $"{EncryptionPrefix}{encryptedText}";
             return result;
         }
-        
-        private object GetMaskedValue(Type destinationType)
+
+        return default;
+    }
+
+    public object GetDecryptedOrDefault(object value, ICryptoTransform decryptor, Type destinationType)
+    {
+        if (value is null)
         {
-            if (destinationType == typeof(string))
-            {
-                const string templateText = "***";
-                return templateText;
-            }
-            var defaultValue = Activator.CreateInstance(destinationType);
-            return defaultValue;
+            throw new ArgumentNullException(nameof(value));
         }
+        var isText = value is string;
+        if (isText)
+        {
+            var valueAsText = (string)value;
+            var isEncrypted = valueAsText.StartsWith(EncryptionPrefix);
+            if (isEncrypted)
+            {
+                var isDecryptorAvailable = decryptor != null;
+                if (isDecryptorAvailable)
+                {
+                    var startIndex = EncryptionPrefix.Length;
+                    var valueWithoutPrefix = valueAsText.Substring(startIndex);
+                    var encryptedValue = Convert.FromBase64String(valueWithoutPrefix);
+                    using var memoryStream = new MemoryStream(encryptedValue);
+                    using var cryptoStream = new CryptoStream(memoryStream, decryptor, CryptoStreamMode.Read);
+                    using var reader = new StreamReader(cryptoStream);
+                    var decryptedText = reader.ReadToEnd();
+                    var result = Parse(destinationType, decryptedText);
+                    return result;
+                }
+                var maskedValue = GetMaskedValue(destinationType);
+                return maskedValue;
+            }
+            var valueParsed = Parse(destinationType, valueAsText);
+            return valueParsed;
+        }
+
+        return value;
+    }
+
+    private object Parse(Type outputType, string valueAsString)
+    {
+        var converter = TypeDescriptor.GetConverter(outputType);
+        var result = converter.ConvertFromString(valueAsString);
+        return result;
+    }
+        
+    private object GetMaskedValue(Type destinationType)
+    {
+        if (destinationType == typeof(string))
+        {
+            const string templateText = "***";
+            return templateText;
+        }
+        var defaultValue = Activator.CreateInstance(destinationType);
+        return defaultValue;
     }
 }

--- a/Crypto_Shredding/.NET/src/CryptoShredding/Serialization/JsonSerializer.cs
+++ b/Crypto_Shredding/.NET/src/CryptoShredding/Serialization/JsonSerializer.cs
@@ -6,87 +6,86 @@ using CryptoShredding.Attributes;
 using CryptoShredding.Contracts;
 using Newtonsoft.Json;
 
-namespace CryptoShredding.Serialization
+namespace CryptoShredding.Serialization;
+
+public class JsonSerializer
 {
-    public class JsonSerializer
+    private const string MetadataSubjectIdKey = "dataSubjectId";
+        
+    private readonly JsonSerializerSettingsFactory _jsonSerializerSettingsFactory;
+    private readonly IEnumerable<Type> _supportedEvents;
+
+    public JsonSerializer(
+        JsonSerializerSettingsFactory jsonSerializerSettingsFactory,
+        IEnumerable<Type> supportedEvents)
     {
-        private const string MetadataSubjectIdKey = "dataSubjectId";
+        _jsonSerializerSettingsFactory = jsonSerializerSettingsFactory;
+        _supportedEvents = supportedEvents;
+    }
         
-        private readonly JsonSerializerSettingsFactory _jsonSerializerSettingsFactory;
-        private readonly IEnumerable<Type> _supportedEvents;
-
-        public JsonSerializer(
-            JsonSerializerSettingsFactory jsonSerializerSettingsFactory,
-            IEnumerable<Type> supportedEvents)
-        {
-            _jsonSerializerSettingsFactory = jsonSerializerSettingsFactory;
-            _supportedEvents = supportedEvents;
-        }
-        
-        public SerializedEvent Serialize(IEvent @event)
-        {
-            var dataSubjectId = GetDataSubjectId(@event);
-            var metadataValues = 
-                new Dictionary<string, string>
-                {
-                    {MetadataSubjectIdKey, dataSubjectId}
-                };
-            
-            var hasPersonalData = dataSubjectId != null;
-            var dataJsonSerializerSettings =
-                hasPersonalData
-                    ? _jsonSerializerSettingsFactory.CreateForEncryption(dataSubjectId)
-                    : _jsonSerializerSettingsFactory.CreateDefault();
-            
-            var dataJson = JsonConvert.SerializeObject(@event, dataJsonSerializerSettings);
-            var dataBytes = Encoding.UTF8.GetBytes(dataJson);
-
-            var defaultJsonSettings = _jsonSerializerSettingsFactory.CreateDefault();
-            var metadataJson = JsonConvert.SerializeObject(metadataValues, defaultJsonSettings);
-            var metadataBytes = Encoding.UTF8.GetBytes(metadataJson);
-            var serializedEvent = new SerializedEvent(dataBytes, metadataBytes, true);
-            return serializedEvent;
-        }
-
-        public IEvent Deserialize(ReadOnlyMemory<byte> data, ReadOnlyMemory<byte> metadata, string eventName)
-        {
-            var metadataJson = Encoding.UTF8.GetString(metadata.Span);
-            var defaultJsonSettings = _jsonSerializerSettingsFactory.CreateDefault();
-            var values =
-                JsonConvert.DeserializeObject<IDictionary<string, string>>(metadataJson, defaultJsonSettings);
-            
-            var hasKey = values.TryGetValue(MetadataSubjectIdKey, out var dataSubjectId);
-            var hasPersonalData = hasKey && !string.IsNullOrEmpty(dataSubjectId);
-
-            var dataJsonDeserializerSettings =
-                hasPersonalData
-                    ? _jsonSerializerSettingsFactory.CreateForDecryption(dataSubjectId)
-                    : _jsonSerializerSettingsFactory.CreateDefault();
-
-            var eventType = _supportedEvents.Single(x => x.Name == eventName);
-            var dataJson = Encoding.UTF8.GetString(data.Span);
-            var persistableEvent = 
-                JsonConvert.DeserializeObject(dataJson, eventType, dataJsonDeserializerSettings);
-            return (IEvent)persistableEvent;
-        }
-        
-        private string GetDataSubjectId(IEvent @event)
-        {
-            var eventType = @event.GetType();
-            var properties = eventType.GetProperties();
-            var dataSubjectIdPropertyInfo =
-                properties
-                    .FirstOrDefault(x => x.GetCustomAttributes(typeof(DataSubjectIdAttribute), false)
-                        .Any(y => y is DataSubjectIdAttribute));
-
-            if (dataSubjectIdPropertyInfo is null)
+    public SerializedEvent Serialize(IEvent @event)
+    {
+        var dataSubjectId = GetDataSubjectId(@event);
+        var metadataValues = 
+            new Dictionary<string, string>
             {
-                return null;
-            }
+                {MetadataSubjectIdKey, dataSubjectId}
+            };
+            
+        var hasPersonalData = dataSubjectId != null;
+        var dataJsonSerializerSettings =
+            hasPersonalData
+                ? _jsonSerializerSettingsFactory.CreateForEncryption(dataSubjectId)
+                : _jsonSerializerSettingsFactory.CreateDefault();
+            
+        var dataJson = JsonConvert.SerializeObject(@event, dataJsonSerializerSettings);
+        var dataBytes = Encoding.UTF8.GetBytes(dataJson);
 
-            var value = dataSubjectIdPropertyInfo.GetValue(@event);
-            var dataSubjectId = value.ToString();
-            return dataSubjectId;
+        var defaultJsonSettings = _jsonSerializerSettingsFactory.CreateDefault();
+        var metadataJson = JsonConvert.SerializeObject(metadataValues, defaultJsonSettings);
+        var metadataBytes = Encoding.UTF8.GetBytes(metadataJson);
+        var serializedEvent = new SerializedEvent(dataBytes, metadataBytes, true);
+        return serializedEvent;
+    }
+
+    public IEvent Deserialize(ReadOnlyMemory<byte> data, ReadOnlyMemory<byte> metadata, string eventName)
+    {
+        var metadataJson = Encoding.UTF8.GetString(metadata.Span);
+        var defaultJsonSettings = _jsonSerializerSettingsFactory.CreateDefault();
+        var values =
+            JsonConvert.DeserializeObject<IDictionary<string, string>>(metadataJson, defaultJsonSettings);
+            
+        var hasKey = values.TryGetValue(MetadataSubjectIdKey, out var dataSubjectId);
+        var hasPersonalData = hasKey && !string.IsNullOrEmpty(dataSubjectId);
+
+        var dataJsonDeserializerSettings =
+            hasPersonalData
+                ? _jsonSerializerSettingsFactory.CreateForDecryption(dataSubjectId)
+                : _jsonSerializerSettingsFactory.CreateDefault();
+
+        var eventType = _supportedEvents.Single(x => x.Name == eventName);
+        var dataJson = Encoding.UTF8.GetString(data.Span);
+        var persistableEvent = 
+            JsonConvert.DeserializeObject(dataJson, eventType, dataJsonDeserializerSettings);
+        return (IEvent)persistableEvent;
+    }
+        
+    private string GetDataSubjectId(IEvent @event)
+    {
+        var eventType = @event.GetType();
+        var properties = eventType.GetProperties();
+        var dataSubjectIdPropertyInfo =
+            properties
+                .FirstOrDefault(x => x.GetCustomAttributes(typeof(DataSubjectIdAttribute), false)
+                    .Any(y => y is DataSubjectIdAttribute));
+
+        if (dataSubjectIdPropertyInfo is null)
+        {
+            return null;
         }
+
+        var value = dataSubjectIdPropertyInfo.GetValue(@event);
+        var dataSubjectId = value.ToString();
+        return dataSubjectId;
     }
 }

--- a/Crypto_Shredding/.NET/src/CryptoShredding/Serialization/JsonSerializerSettingsFactory.cs
+++ b/Crypto_Shredding/.NET/src/CryptoShredding/Serialization/JsonSerializerSettingsFactory.cs
@@ -3,52 +3,51 @@ using CryptoShredding.Serialization.JsonConverters;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
-namespace CryptoShredding.Serialization
-{
-    public class JsonSerializerSettingsFactory
-    {
-        private readonly EncryptorDecryptor _encryptorDecryptor;
+namespace CryptoShredding.Serialization;
 
-        public JsonSerializerSettingsFactory(EncryptorDecryptor encryptorDecryptor)
-        {
-            _encryptorDecryptor = encryptorDecryptor;
-        }
+public class JsonSerializerSettingsFactory
+{
+    private readonly EncryptorDecryptor _encryptorDecryptor;
+
+    public JsonSerializerSettingsFactory(EncryptorDecryptor encryptorDecryptor)
+    {
+        _encryptorDecryptor = encryptorDecryptor;
+    }
         
-        public JsonSerializerSettings CreateDefault()
-        {
-            var defaultContractResolver = new CamelCasePropertyNamesContractResolver();
-            var defaultSettings = GetSettings(defaultContractResolver);
-            return defaultSettings;
-        }
+    public JsonSerializerSettings CreateDefault()
+    {
+        var defaultContractResolver = new CamelCasePropertyNamesContractResolver();
+        var defaultSettings = GetSettings(defaultContractResolver);
+        return defaultSettings;
+    }
         
-        public JsonSerializerSettings CreateForEncryption(string dataSubjectId)
-        {
-            var encryptor = _encryptorDecryptor.GetEncryptor(dataSubjectId);
-            var fieldEncryptionDecryption = new FieldEncryptionDecryption();
-            var serializationContractResolver = 
-                new SerializationContractResolver(encryptor, fieldEncryptionDecryption);
-            var jsonSerializerSettings = GetSettings(serializationContractResolver);
-            return jsonSerializerSettings;
-        }
+    public JsonSerializerSettings CreateForEncryption(string dataSubjectId)
+    {
+        var encryptor = _encryptorDecryptor.GetEncryptor(dataSubjectId);
+        var fieldEncryptionDecryption = new FieldEncryptionDecryption();
+        var serializationContractResolver = 
+            new SerializationContractResolver(encryptor, fieldEncryptionDecryption);
+        var jsonSerializerSettings = GetSettings(serializationContractResolver);
+        return jsonSerializerSettings;
+    }
         
-        public JsonSerializerSettings CreateForDecryption(string dataSubjectId)
-        {
-            var decryptor = _encryptorDecryptor.GetDecryptor(dataSubjectId);
-            var fieldEncryptionDecryption = new FieldEncryptionDecryption();
-            var deserializationContractResolver = 
-                new DeserializationContractResolver(decryptor, fieldEncryptionDecryption);
-            var jsonDeserializerSettings = GetSettings(deserializationContractResolver);
-            return jsonDeserializerSettings;
-        }
+    public JsonSerializerSettings CreateForDecryption(string dataSubjectId)
+    {
+        var decryptor = _encryptorDecryptor.GetDecryptor(dataSubjectId);
+        var fieldEncryptionDecryption = new FieldEncryptionDecryption();
+        var deserializationContractResolver = 
+            new DeserializationContractResolver(decryptor, fieldEncryptionDecryption);
+        var jsonDeserializerSettings = GetSettings(deserializationContractResolver);
+        return jsonDeserializerSettings;
+    }
         
-        private JsonSerializerSettings GetSettings(IContractResolver contractResolver)
-        {
-            var settings =
-                new JsonSerializerSettings
-                {
-                    ContractResolver = contractResolver
-                };
-            return settings;
-        }
+    private JsonSerializerSettings GetSettings(IContractResolver contractResolver)
+    {
+        var settings =
+            new JsonSerializerSettings
+            {
+                ContractResolver = contractResolver
+            };
+        return settings;
     }
 }

--- a/Crypto_Shredding/.NET/src/CryptoShredding/Serialization/SerializedEvent.cs
+++ b/Crypto_Shredding/.NET/src/CryptoShredding/Serialization/SerializedEvent.cs
@@ -1,16 +1,15 @@
-namespace CryptoShredding.Serialization
+namespace CryptoShredding.Serialization;
+
+public class SerializedEvent
 {
-    public class SerializedEvent
-    {
-        public byte[] Data { get; }
-        public byte[] MetaData { get; }
-        public bool IsJson { get; }
+    public byte[] Data { get; }
+    public byte[] MetaData { get; }
+    public bool IsJson { get; }
         
-        public SerializedEvent(byte[] data, byte[] metaData, bool isJson)
-        {
-            Data = data;
-            MetaData = metaData;
-            IsJson = isJson;
-        }
+    public SerializedEvent(byte[] data, byte[] metaData, bool isJson)
+    {
+        Data = data;
+        MetaData = metaData;
+        IsJson = isJson;
     }
 }


### PR DESCRIPTION
- Updated .NET CQRS flow to .NET 6, bumped packages to the latest version
- Moved to file-scoped namespaces.
- Updated obsolete usage of AesManaged to Aes.Create. From: https://www.meziantou.net/cryptography-in-dotnet.htm#aes:
  > "AESManaged is fully implemented in .NET, however, the implementation is not FIPS compliant. AESCryptoServiceProvider uses the Windows implementation (CryptoAPI) which is FIPS compliant. Or you can create an instance of the best available provider using AES.Create()."

_**Note for reviewers:** Review with whitespace hidden, there is ten time less line change https://github.com/EventStore/samples/pull/13/files?diff=split&w=1_