### PR TITLE
DEV-249 - Fix broken CI for Java CQRS flow sample

### DIFF
--- a/CQRS_Flow/Java/event-sourcing-esdb-aggregates/src/main/java/io/eventdriven/ecommerce/shoppingcarts/gettingbyid/GetShoppingCartById.java
+++ b/CQRS_Flow/Java/event-sourcing-esdb-aggregates/src/main/java/io/eventdriven/ecommerce/shoppingcarts/gettingbyid/GetShoppingCartById.java
@@ -16,6 +16,6 @@ public record GetShoppingCartById(
   ) {
     return query.eTag() == null ?
       repository.findById(query.shoppingCartId())
-      : repository.findByIdAndVersionOrNewer(query.shoppingCartId(), query.eTag().toLong());
+      : repository.findByIdAndNeverVersion(query.shoppingCartId(), query.eTag().toLong());
   }
 }

--- a/CQRS_Flow/Java/event-sourcing-esdb-aggregates/src/main/java/io/eventdriven/ecommerce/shoppingcarts/gettingbyid/ShoppingCartDetailsRepository.java
+++ b/CQRS_Flow/Java/event-sourcing-esdb-aggregates/src/main/java/io/eventdriven/ecommerce/shoppingcarts/gettingbyid/ShoppingCartDetailsRepository.java
@@ -10,6 +10,6 @@ import java.util.UUID;
 @Repository
 public interface ShoppingCartDetailsRepository
   extends JpaRepository<ShoppingCartDetails, UUID> {
-  @Query("SELECT d FROM ShoppingCartDetails d WHERE d.id = ?1 AND d.version >= ?2")
-  Optional<ShoppingCartDetails> findByIdAndVersionOrNewer(UUID id, long version);
+  @Query("SELECT d FROM ShoppingCartDetails d WHERE d.id = ?1 AND d.version > ?2")
+  Optional<ShoppingCartDetails> findByIdAndNeverVersion(UUID id, long version);
 }

--- a/CQRS_Flow/Java/event-sourcing-esdb-simple/src/main/java/io/eventdriven/ecommerce/shoppingcarts/gettingbyid/GetShoppingCartById.java
+++ b/CQRS_Flow/Java/event-sourcing-esdb-simple/src/main/java/io/eventdriven/ecommerce/shoppingcarts/gettingbyid/GetShoppingCartById.java
@@ -16,6 +16,6 @@ public record GetShoppingCartById(
   ) {
     return query.eTag() == null ?
       repository.findById(query.shoppingCartId())
-      : repository.findByIdAndVersionOrNewer(query.shoppingCartId(), query.eTag().toLong());
+      : repository.findByIdAndNeverVersion(query.shoppingCartId(), query.eTag().toLong());
   }
 }

--- a/CQRS_Flow/Java/event-sourcing-esdb-simple/src/main/java/io/eventdriven/ecommerce/shoppingcarts/gettingbyid/ShoppingCartDetailsRepository.java
+++ b/CQRS_Flow/Java/event-sourcing-esdb-simple/src/main/java/io/eventdriven/ecommerce/shoppingcarts/gettingbyid/ShoppingCartDetailsRepository.java
@@ -10,6 +10,6 @@ import java.util.UUID;
 @Repository
 public interface ShoppingCartDetailsRepository
   extends JpaRepository<ShoppingCartDetails, UUID> {
-  @Query("SELECT d FROM ShoppingCartDetails d WHERE d.id = ?1 AND d.version >= ?2")
-  Optional<ShoppingCartDetails> findByIdAndVersionOrNewer(UUID id, long version);
+  @Query("SELECT d FROM ShoppingCartDetails d WHERE d.id = ?1 AND d.version > ?2")
+  Optional<ShoppingCartDetails> findByIdAndNeverVersion(UUID id, long version);
 }


### PR DESCRIPTION
Rolling back contribution from @SamAllen83 in #31 due to failing CI (test failure) on the Java CQRS flow samples.

The PR originated from a fork and did not trigger the CI, meaning the failing test(s) were not identified before merging.

Some tests are failing due to Eventual Consistency, whereby views under test have not yet converged/are not consistent with expectation, in combination with `If-None-Match` behaviour.

A Linear issue has been added to the backlog ([DEV-251](https://linear.app/eventstore/issue/DEV-251/account-for-eventual-consistency-in-java-cqrs-samples)) to implement a proper fix.