### PR TITLE
Moving version check to demonstrate optimistic concurrency

### DIFF
--- a/LoanApplication/Python/CreditCheck.py
+++ b/LoanApplication/Python/CreditCheck.py
@@ -54,6 +54,9 @@ persistent_subscription = esdb.read_subscription_to_stream(group_name=config.GRO
 for loan_request_event in persistent_subscription:
     # Introduce some delay
     time.sleep(5)
+    
+    # Get the current commit version of the loan request stream for this loan request
+    COMMIT_VERSION = esdb.get_current_version(stream_name=loan_request_event.stream_name)
 
     if config.DEBUG:
         print('  Received event: id=' + str(loan_request_event.id) + '; type=' + loan_request_event.type + '; stream_name=' + str(loan_request_event.stream_name) + '; data=\'' +  str(loan_request_event.data) + '\'')
@@ -88,8 +91,6 @@ for loan_request_event in persistent_subscription:
     
     print('  Processing credit check - CreditChecked for NationalID ' + str(_credit_checked_event_data["NationalID"]) + ' with a Score of ' + str(_credit_checked_event_data["Score"]))
 
-    # Get the current commit version of the loan request stream for this loan request
-    COMMIT_VERSION = esdb.get_current_version(stream_name=loan_request_event.stream_name)
     # Append the event to the stream
     CURRENT_POSITION = esdb.append_to_stream(stream_name=loan_request_event.stream_name, current_version=COMMIT_VERSION, events=[credit_checked_event])
 

--- a/LoanApplication/Python/LoanDecider.py
+++ b/LoanApplication/Python/LoanDecider.py
@@ -65,6 +65,9 @@ for credit_check_event in catchup_subscription:
     # Introduce some delay
     time.sleep(5)
     
+    # Get the current commit version for the stream to which we will append
+    COMMIT_VERSION = esdb.get_current_version(stream_name=credit_check_event.stream_name)
+    
     if config.DEBUG:
         print('  Received event: id=' + str(credit_check_event.id) + '; type=' + credit_check_event.type + '; stream_name=' + str(credit_check_event.stream_name) + '; data=\'' +  str(credit_check_event.data) + '\'')
 
@@ -109,8 +112,6 @@ for credit_check_event in catchup_subscription:
     
     print('  Processing loan decision for ' + _state_data['User'] + ' with Score of ' + str(_state_data['Score']) + ' - ' + _decision_event_type + '\n  Appending to stream: ' + credit_check_event.stream_name + '\n')
     
-    # Get the current commit version for the stream to which we will append
-    COMMIT_VERSION = esdb.get_current_version(stream_name=credit_check_event.stream_name)
     # Append the decision event to the stream
     CURRENT_POSITION = esdb.append_to_stream(stream_name=credit_check_event.stream_name, current_version=COMMIT_VERSION, events=[decision_event])
 

--- a/LoanApplication/Python/Underwriting.py
+++ b/LoanApplication/Python/Underwriting.py
@@ -64,6 +64,12 @@ print('Waiting for events')
 
 # For each event received through the subscription (note: this is a blocking operation)
 for decision_needed_event in catchup_subscription:
+    # Introduce some delay
+    time.sleep(5)
+
+    # Get the commit version to use for appending the decision event
+    COMMIT_VERSION = esdb.get_current_version(stream_name=decision_needed_event.stream_name)
+
     if config.DEBUG:
         print('  Received event: id=' + str(decision_needed_event.id) + '; type=' + decision_needed_event.type + '; stream_name=' + str(decision_needed_event.stream_name) + '; data=\'' +  str(decision_needed_event.data) + '\'')
 
@@ -116,8 +122,6 @@ for decision_needed_event in catchup_subscription:
     else:
         print('  Processing loan decision - ' + _decision_event_type + '\n')
     
-    # Get the commit version to use for appending the decision event
-    COMMIT_VERSION = esdb.get_current_version(stream_name=decision_needed_event.stream_name)
     # Append the decision event
     CURRENT_POSITION = esdb.append_to_stream(stream_name=decision_needed_event.stream_name, current_version=COMMIT_VERSION, events=[decision_event])
 


### PR DESCRIPTION
Moving the version check up in the code so we can eventually demo optimistic concurrency